### PR TITLE
Specify browserify as a peerDependency!

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,5 +28,8 @@
   },
   "dependencies": {
     "through": "~2.2.0"
+  },
+  "peerDependencies": {
+    "browserify": ">= 2.4.0 < 3"
   }
 }


### PR DESCRIPTION
That way people won't try to use it with browserify v1 or v2.3 or similar.
