### PR TITLE
Removed unnecessary buildScriptDir

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,6 @@ var path    =  require('path')
   , fs      =  require('fs')
   , format  =  require('util').format
   , through =  require('through')
-  , buildScriptDir    =  path.dirname(module.parent.filename)
   ;
 
 function inspect(obj, depth) {
@@ -87,7 +86,7 @@ module.exports = function shim(browserifyInstance, configs) {
 
       validate(config);
 
-      var resolvedPath = require.resolve(path.resolve(buildScriptDir, config.path));
+      var resolvedPath = require.resolve(path.resolve(config.path));
 
       shims[resolvedPath] = config;
       browserifyInstance.require(resolvedPath, { expose: alias });


### PR DESCRIPTION
I believe this was meant to make `path.resolve()` operate from the same directory `shim()` was called from, but that appears to be the default behavior. Removing it does not appear to change anything, except allowing `browserify-shim` to be included by another module (`grunt-browserify` in my case) and `shim()` to be called by it directly.
