### PR TITLE
Fixed escaping issue for win32 dependency paths with backslashes

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,14 +49,15 @@ function requireDependencies(depends, packageRoot, browserAliases, dependencies)
     .map(customResolve)
     .reduce(
       function (acc, dep) {
+        var alias = dep.alias.replace(/\\/g, "\\\\");
         return dep.exports 
           // Example: jQuery = global.jQuery = require("jquery");
           // the global dangling variable is needed cause some libs reference it as such and it breaks outside of the browser,
           // i.e.: (function ($) { ... })( jQuery )
           // This little extra makes it work everywhere and since it's on top, it will be shadowed by any other definitions 
           // so it doesn't conflict with anything.
-          ? acc + dep.exports + ' = global.' + dep.exports + ' = require("' + dep.alias + '");\n'
-          : acc + 'require("' + dep.alias + '");\n';
+          ? acc + dep.exports + ' = global.' + dep.exports + ' = require("' + alias + '");\n'
+          : acc + 'require("' + alias + '");\n';
       }
     , '\n; '
   );


### PR DESCRIPTION
When the alias is a string containing e.g. backslashes, as happens with Windows paths, escaping is needed before inserting it into the generated code.
