### PR TITLE
Fixed shim.js example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ Below are three examples, each showing a way to properly shim the above mentione
 
 ```js
 module.exports = {
-  '../vendor/x.js'    :  '$',
+  '../vendor/x.js'    :  { 'exports': '$' },
   '../vendor/x-ui.js' :  { 'depends': { '../vendor/x.js': null } },
   '../vendor/y.js'    :  { 'exports': 'Y', 'depends': { '../vendor/x.js': '$' } },
   '../vendor/z.js'    :  { 'exports': 'zorro', 'depends': { '../vendor/x.js': '$', '../vendor/y.js': 'YNOT' } }


### PR DESCRIPTION
The shorthand syntax for shims ("module": "globalVar") doesn't work in external shim configs.  I changed the README to reflect his.
