### PR TITLE
Added a new test for bundling vendor libraries in a separate bundle.

### DIFF
--- a/test/bundle-external.js
+++ b/test/bundle-external.js
@@ -7,15 +7,15 @@ var browserify = require('browserify')
 
 function bundleNcheck(relPath, t) {
   browserify( { ignoreGlobals: true })
-    .require(require.resolve(relPath + '/../vendor/non-cjs.js'))
-    .require(require.resolve(relPath + '/../vendor/non-cjs-dep.js'))
+    .require(require.resolve(relPath + '/../vendor/non-cjs.js'), { expose: 'non-cjs' })
+    .require(require.resolve(relPath + '/../vendor/non-cjs-dep.js'), { expose: 'non-cjs-dep' })
     .bundle(function (err, srcLibs) {
       if (err) { t.fail(err); return t.end(); }
 
       browserify( { ignoreGlobals: true })
         .require(require.resolve(relPath))
-        .external(require.resolve(relPath + '/../vendor/non-cjs.js'))
-        .external(require.resolve(relPath + '/../vendor/non-cjs-dep.js'))
+        .external('non-cjs')
+        .external('non-cjs-dep')
         .bundle(function (err, src) {
           if (err) { t.fail(err); return t.end(); }
 


### PR DESCRIPTION
This test should reproduce an issue with bundling vendor libraries in a separate bundle using browserify@5.

This test is passed when it runs against browserify@4 but fails against browserify@5.
