### PR TITLE
Permits exporting a string literal as a shim

### DIFF
--- a/index.js
+++ b/index.js
@@ -141,7 +141,10 @@ function bindWindowWithoutExports(s, dependencies) {
 }
 
 function moduleExport(exp) {
-  return format('\n; browserify_shim__define__module__export__(typeof %s != "undefined" ? %s : window.%s);\n', exp, exp, exp);
+  return format('\n; browserify_shim__define__module__export__(typeof %s != "undefined" ? %s : %s);\n'
+                , exp
+                , exp
+                , format(exp.match(/^\'.*\'$/) ? '%s' : 'window.%s', exp));
 }
 
 function wrap(content, config, packageRoot, browserAliases) {

--- a/test/shim/shim-exports-string.js
+++ b/test/shim/shim-exports-string.js
@@ -1,0 +1,18 @@
+'use strict';
+/*jshint asi: true*/
+
+var testLib = require('./utils/test-lib')
+  , test = require('tap').test
+  , baseUrl = 'https://raw.github.com/documentcloud/underscore/master/'
+
+// Demonstrates shimming a module as a string literal
+test('config exports a string', function (t) {
+  var shimConfig = { exports: "'underscore'" }
+  testLib(t, { 
+      name: 'underscore.js'
+    , test: function (t, resolved) { t.equals(resolved, 'underscore', 'require resolves to the string') }
+    , asserts: 1
+    , shimConfig: shimConfig
+    , baseUrl: baseUrl
+  })
+});


### PR DESCRIPTION
I had a need for this so feel free to merge in if you think it might be useful to others. Basically just let's you shim a module as a simple string, i.e. in your config:

```
"browserify-shim": {
  "./angular/angular-route.js": "'ngRoute'"
}
```

So when required:

```
var ngRoute = require("angular-route");    // ngRoute == 'ngRoute'
```

I specifically needed this so I could tie in seamlessly with Angular's module system:

```
angular.module("ModuleName", [ require("angular-route") ]);
```

But yeah, might be a limited use case.
