### PR TITLE
set peerDependency browserify to max version 8

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,6 @@
     "through": "~2.3.4"
   },
   "peerDependencies": {
-    "browserify": ">= 2.3.0 < 7"
+    "browserify": ">= 2.3.0 < 8"
   }
 }


### PR DESCRIPTION
since browserify was updated to  7.0 browserify-shim won't install but is not actually effected by the major change.
https://github.com/substack/node-browserify/blob/master/doc/changelog/7_0.markdown
