### PR TITLE
dependency-with-global: Add an example

### DIFF
--- a/examples/dependency-with-global/.bin/browserify
+++ b/examples/dependency-with-global/.bin/browserify
@@ -1,0 +1,1 @@
+../browserify/bin/cmd.js

--- a/examples/dependency-with-global/Readme.md
+++ b/examples/dependency-with-global/Readme.md
@@ -1,0 +1,63 @@
+# Browserify-Shim 
+
+This example demonstrates how to create a browserify-aware dependency with a dependency on a global.
+
+The important part is in `node_modules/my-3d-library/package.json`:
+
+```json
+  "browserify-shim": {
+    "three": "global:THREE"
+  },
+  "browserify": {
+    "transform": [
+      "browserify-shim"
+    ]
+  }
+```
+
+### Bundling via the command line
+
+Given this config you can build the bundle via: 
+
+    browserify -d . > js/bundle.js
+
+demonstrated [here](https://github.com/thlorenz/browserify-shim/blob/master/examples/expose-jquery/cli.sh).
+
+If you want to turn on browserify shim diagnostics messages set the `BROWSERIFYSHIM_DIAGNOSTICS` environment variable
+when bundling i.e.:
+
+    BROWSERIFYSHIM_DIAGNOSTICS=1 browserify -d . > js/bundle.js
+
+demonstrated [here](https://github.com/thlorenz/browserify-shim/blob/master/examples/expose-jquery/cli-diag.sh).
+
+**Note** that in both cases the `-d` flag is added as well in order to turn on browserify sourcemaps.  
+
+**Note** `.` tells browserify to use the current dir as the root of the bundling chain. As a result it finds `"main":
+"./js/entry.js"` in the `package.json` and thus uses that as the entry point.
+
+### Bundling via a `.js` script
+
+Alternatively you can write a short `build.js` to perform the bundling step:
+
+```js
+  browserify()  
+    .require(require.resolve('./'), { entry: true })
+    .bundle({ debug: true })
+    .on('error', console.error.bind(console)) 
+    .pipe(fs.createWriteStream(path.join(__dirname, 'js', 'bundle.js'), 'utf8'))
+```
+
+demonstrated [here](https://github.com/thlorenz/browserify-shim/blob/master/examples/expose-jquery/build.js).
+
+To run this example:
+
+    npm install browserify-shim
+    npm explore browserify-shim
+
+Then:
+
+    npm run dependency-with-global
+
+Or to see diagnostic messages:
+
+    npm run dependency-with-global-diag

--- a/examples/dependency-with-global/build-diag.js
+++ b/examples/dependency-with-global/build-diag.js
@@ -1,0 +1,23 @@
+'use strict';
+
+process.env.BROWSERIFYSHIM_DIAGNOSTICS = 1;
+
+var path       = require('path')
+  , fs         = require('fs')
+  , browserify = require('browserify')
+  ;
+
+(function bundle() {
+  // This is function is the important part and should be similar to what you would use for your project
+  var builtFile = path.join(__dirname, 'js', 'bundle.js');
+
+  browserify()  
+    // this resolves main file of our package
+    .require(require.resolve('./'), { entry: true })
+    .bundle({ debug: true })
+    .on('end', function () {
+      console.log('Build succeeded, open index.html to see the result.');
+    })
+    .on('error', console.error.bind(console)) 
+    .pipe(fs.createWriteStream(builtFile, 'utf8'))
+})();

--- a/examples/dependency-with-global/build.js
+++ b/examples/dependency-with-global/build.js
@@ -1,0 +1,21 @@
+'use strict';
+
+var path       = require('path')
+  , fs         = require('fs')
+  , browserify = require('browserify')
+  ;
+
+(function bundle() {
+  // This is function is the important part and should be similar to what you would use for your project
+  var builtFile = path.join(__dirname, 'js', 'bundle.js');
+
+  browserify()  
+    // this resolves main file of our package
+    .require(require.resolve('./'), { entry: true })
+    .bundle({ debug: true })
+    .on('end', function () {
+      console.log('Build succeeded, open index.html to see the result.');
+    })
+    .on('error', console.error.bind(console)) 
+    .pipe(fs.createWriteStream(builtFile, 'utf8'))
+})();

--- a/examples/dependency-with-global/cli-diag.sh
+++ b/examples/dependency-with-global/cli-diag.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+BROWSERIFYSHIM_DIAGNOSTICS=1 ./node_modules/.bin/browserify -d . > js/bundle.js
+
+open index.html

--- a/examples/dependency-with-global/cli.sh
+++ b/examples/dependency-with-global/cli.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+./node_modules/.bin/browserify -d . > js/bundle.js
+
+open index.html

--- a/examples/dependency-with-global/index.html
+++ b/examples/dependency-with-global/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset=utf-8 />
+  <title>dependency with global example</title>
+  <script type="text/javascript" src="http://code.jquery.com/jquery-2.0.3.min.js"></script>
+  <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r69/three.min.js"></script>
+</head>
+<body>
+  <h1>Welcome to the browserify-shim dependency with global Example</h1>
+  <p>You are using Three.js version:</p>
+  <span id='three-version'></span>
+  <p>
+    If you open your devtools and find <code>entry.js</code> or <code>bundle.js</code> you will see that <code>require('three')</code> was replaced with <code>(window.THREE)</code>.
+  </p>
+  <script type="text/javascript" src="./js/bundle.js"></script>
+</body>
+</html>

--- a/examples/dependency-with-global/js/entry.js
+++ b/examples/dependency-with-global/js/entry.js
@@ -1,0 +1,4 @@
+var my3dLibrary = require('my-3d-library')
+  , $ = require('jquery');
+
+$('#three-version').text('r' + my3dLibrary.threeVersion);

--- a/examples/dependency-with-global/package.json
+++ b/examples/dependency-with-global/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "dependency-with-global",
+  "version": "0.0.0",
+  "description": "Example of using browserify-shim with a dependency that requires a separately loaded global.",
+  "main": "./js/entry.js",
+  "browserify-shim": {
+    "jquery": "global:$"
+  },
+  "browserify": {
+    "transform": [
+      "browserify-shim"
+    ]
+  },
+  "repository": "",
+  "author": "Paul Melnikow",
+  "license": "BSD",
+  "dependencies": {
+    "request": "~2.12.0"
+  },
+  "devDependencies": {
+    "browserify": "~2.36.1",
+    "browserify-shim": "~3.2.0"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
     "shim-jquery": "npm install opener && cd ./examples/shim-jquery && npm install && node build.js && opener index.html",
     "shim-jquery-diag": "npm install opener && cd ./examples/shim-jquery && npm install && node build-diag.js && opener index.html",
     "expose-jquery": "npm install opener && cd ./examples/expose-jquery && npm install && node build.js && opener index.html",
-    "expose-jquery-diag": "npm install opener && cd ./examples/expose-jquery && npm install && node build-diag.js && opener index.html"
+    "expose-jquery-diag": "npm install opener && cd ./examples/expose-jquery && npm install && node build-diag.js && opener index.html",
+    "dependency-with-global": "npm install opener && cd ./examples/dependency-with-global && npm install && node build.js && opener index.html",
+    "dependency-with-global-diag": "npm install opener && cd ./examples/dependency-with-global && npm install && node build-diag.js && opener index.html"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This example shows how to create a browserify-aware dependency which requires a global.