### PR TITLE
remove '.js' so config file example works

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ In case you are using an external shim config, you may achieve the same by speci
 
 ```js
 module.exports = {
-  'three.js': { exports: 'global:THREE' }
+  'three': { exports: 'global:THREE' }
 }
 ```
 


### PR DESCRIPTION
this brings the config file example into line with the subsequent require part of the three.js example.