### PR TITLE
Make tests iojs only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: node_js
 node_js:
-  - 0.10
+  - iojs

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "proxyquire": "~0.5.1",
     "request": "~2.12.0",
     "rimraf": "~2.2.6",
-    "tap": "~0.3.3",
+    "tap": "^1.1.0",
     "test-peer-range": "^1.0.1"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   },
   "dependencies": {
     "exposify": "~0.2.0",
+    "jsdom": "^5.4.2",
     "mothership": "~0.2.0",
     "rename-function-calls": "~0.1.0",
     "resolve": "~0.6.1",

--- a/test/shim/utils/test-lib.js
+++ b/test/shim/utils/test-lib.js
@@ -82,7 +82,7 @@ module.exports = function testLib(t, opts) {
         .bundle(function (err, src) {
           if (err) return cb(err);
 
-          var window = jsdom(html).createWindow()
+          var window = jsdom(html).defaultView
             , context = vm.createContext(window)
 
           Object.keys(window).forEach(function (k) { context[k] = window[k] })


### PR DESCRIPTION
Did some investigating on #163. The problem is that jsdom requires iojs as of v4 (for changes to V8/`vm`). As far as I can tell there's no jsdom that's compatible with 0.10, 0.12, and iojs. Short of spinning up a real browser and totally rewriting the test suite, we have a choice to make here.

1. Leave things as is and advertise that tests are 0.10 only. The rationale would be that there are less likely to be relevant breaking changes in 0.12/iojs that would pass 0.10 tests. The reverse is not as true (e.g. you could use `path.isAbsolute` and unknowingly break 0.10).
2. Go iojs only on tests and just pay attention to not using 0.10 incompatible methods. Since the last code-level contribution not by the two of us was in January '14, this should be easily doable.
3. Add code to the tests to downgrade jsdom and use the older API on 0.10 so we can still run the tests.

My preference is for 2 since b-shim is a relatively low velocity project and it's a build tool. But I'm willing to implement 3 for the best of both worlds. My thought here is that we're both on io and out of all test suite runs we probably represent the vast majority. 