### PR TITLE
Update mothership dependency. Fixes #242

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "exposify": "~0.5.0",
-    "mothership": "~0.2.0",
+    "mothership": "~0.3.0",
     "rename-function-calls": "~0.1.0",
     "resolve": "~0.6.1",
     "through": "~2.3.4"


### PR DESCRIPTION
This fixes the warning outlined in #242 caused by upstream dependencies.