### PR TITLE
resolve-shims: prevent prototype manipulation

### DIFF
--- a/lib/resolve-shims.js
+++ b/lib/resolve-shims.js
@@ -123,6 +123,11 @@ function separateExposeGlobals(shims) {
     , exposeGlobals = {};
 
   Object.keys(shims).forEach(function (k) {
+    // https://github.com/thlorenz/browserify-shim/issues/245
+    if (k === '__proto__' || k === 'constructor') {
+      return;
+    }
+
     var val = shims[k]
       , exp = val && val.exports;
 


### PR DESCRIPTION
Prevents prototype manipulation in the `separateExposeGlobals` function.  The supplied `shims` are parsed from JSON and could in theory contain a `__proto__` key. It is not clear that this is even exploitable to manipulate the any behavior of `exposeGlobals`, let alone the global object prototype.

Nevertheless, out of an abundance of caution, this forbids passing `__proto__` or `constructor` as shims.

Closes #245 