### PR TITLE
Update repository metadata URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/thlorenz/browserify-shim.git"
+    "url": "git+https://github.com/thlorenz/browserify-shim.git"
   },
   "keywords": [
     "browserify",


### PR DESCRIPTION
## Summary
- update the npm repository metadata URL from the legacy git:// protocol to git+https://
- leave runtime code, dependencies, and package behavior unchanged

## Validation
- npm view browserify-shim@3.8.16 name version repository homepage bugs license --json
- npm pack --dry-run --ignore-scripts --json
- git diff --check