### PR TITLE
fix: use git+https:// repository URL instead of legacy git://

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/thlorenz/browserify-shim.git"
+    "url": "git+https://github.com/thlorenz/browserify-shim.git"
   },
   "keywords": [
     "browserify",


### PR DESCRIPTION
Changes `repository.url` from `git://github.com/thlorenz/browserify-shim.git` to `git+https://github.com/thlorenz/browserify-shim.git`

This fixes the deprecated `git://` protocol which is no longer supported by GitHub.