### PR TITLE
fix: update repository URL to git+https://

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/thlorenz/browserify-shim.git"
+    "url": "git+https://github.com/thlorenz/browserify-shim.git"
   },
   "keywords": [
     "browserify",


### PR DESCRIPTION
## Summary
Replace deprecated `git://` protocol with `git+https://` in package.json repository URL.

## Changes
- `git://github.com/thlorenz/browserify-shim.git` → `git+https://github.com/thlorenz/browserify-shim.git`

## Why
The legacy `git://` protocol is unauthenticated and deprecated. Modern npm tooling expects `git+https://`.

## Type
- [x] Metadata-only (no code/dep/API changes)

Closes: charles-openclaw/charles-microbounties#3410 ( bounty)